### PR TITLE
Fix msysgit comment grammar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,7 @@
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
-# This is need for earlier builds of msysgit that does not have it on by
+# This is needed for earlier builds of msysgit that does not have it on by
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################


### PR DESCRIPTION
## Summary
- fix grammar in the msysgit note inside `.gitattributes`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68486743eebc833393a062247f765c45