### PR TITLE
Update config instructions

### DIFF
--- a/Scripts/ninja/config.ps1
+++ b/Scripts/ninja/config.ps1
@@ -6,6 +6,7 @@
     1. Stops "MTD Temperature Monitor" if running.
     2. Sets environment variables (Machine scope) for:
        - TemperatureMonitor:KioskId
+       - TemperatureMonitor:ApiKey
        - VertivSensorWorker:SensorIp  (only if provided)
        - VertivSensorWorker:Enabled
        - AdafruitSensorWorker:Enabled


### PR DESCRIPTION
## Summary
- clarify the setup script to mention TemperatureMonitor:ApiKey

## Testing
- `dotnet build Mtd.Kiosk.TempMonitor.sln -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_6848674d27a08333862dffcd8cd80596